### PR TITLE
ZeroMQServer daemon flag bug

### DIFF
--- a/simpleRaft/servers/server.py
+++ b/simpleRaft/servers/server.py
@@ -71,7 +71,7 @@ class ZeroMQServer(Server):
         self.subscribeThread = SubscribeThread()
         self.publishThread = PublishThread()
 
-        self.subscribeThread.start()
         self.subscribeThread.daemon = True
-        self.publishThread.start()
+        self.subscribeThread.start()
         self.publishThread.daemon = True
+        self.publishThread.start()


### PR DESCRIPTION
This must be set after threading.Thread.__init__(), before thread.start(). Setting it afterwards raises a RuntimeError