### PR TITLE
ZeroMQServer PublishThread fix

### DIFF
--- a/simpleRaft/servers/server.py
+++ b/simpleRaft/servers/server.py
@@ -66,6 +66,8 @@ class ZeroMQServer(Server):
 
                 while True:
                     message = self._messageBoard.get_message()
+                    if not message:
+                        continue # sleep wait?
                     socket.send(message)
 
         self.subscribeThread = SubscribeThread()


### PR DESCRIPTION
Board.get_message is non-blocking returning None in the empty case. ZMQ should not try to broadcast "None" to all members.
FWIW- this would probably do better with a configurable sleep wait to reduce thrashing